### PR TITLE
Added addtocalendar.js to Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,6 @@
     "demo",
     "test",
     "lib",
-    "addtocalendar.js",
     "npm-debug.log",
     "karma.conf.js"
   ],


### PR DESCRIPTION
addtocalendar.js was ignored in bower.json, and therefore not included when installing the directive from Bower.